### PR TITLE
4 update Alain Villagrasa 816787

### DIFF
--- a/fracasar-con-erp.md
+++ b/fracasar-con-erp.md
@@ -227,9 +227,6 @@ El proyecto comenzó en 2000 y finalizó en 2006, con 5 años de retraso y un co
 - **Oracle y PharmaCo (nombre ficticio, China)**:
 [ERP implementation failures in China: Case studies with implications for ERP vendors](http://www.sciencedirect.com/science/article/pii/S0925527304003226) (Fuente: Julián Liaño)
 
-- **PeopleSoft y [University of Wisconsing-Superior](http://www.uwsuper.edu/index.htm)**:
-[Lessons from an ERP Implementation](http://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=946615) (Fuente: Edgar Arnal)
-
 - **SAP y el estado de [Arkansas](http://www.state.ar.us/)**:
 [SAP agrees to fix Arkansas ERP system, settles lawsuit charging that system is not accessible to blind state employees](http://www.computerworld.com/article/2532356/enterprise-applications/sap-agrees-to-fix-arkansas-erp-system.html) (Fuente: Eduardo Mindam). El problema se detectó en 2001 (incumplimiento de la norma de accesibilidad) y se resuelve en 2008 tras llegar un acuerdo para actualizar el sistema para soportar el acceso a personas ciegas (Fuente: Beatriz Franco).
 
@@ -246,7 +243,7 @@ El proyecto comenzó en 2000 y finalizó en 2006, con 5 años de retraso y un co
 [Supplier sues consultant over failed WHSmith SAP roll-out](http://www.computerweekly.com/news/2240042682/Supplier-sues-consultant-over-failed-WHSmith-SAP-roll-out) (Fuente: Celia Langa)
 
 - **SAP y KuDrink**:
-[Rescuing Troubled Software Projects by Team Transformation: A Case Study With an ERP Project](https://ieeexplore.ieee.org/abstract/document/4439890) (Fuente: Sergio García-Campero)
+[Rescuing Troubled Software Projects by Team Transformation: A Case Study With an ERP Project](https://www.researchgate.net/publication/3077076_Rescuing_Troubled_Software_Projects_by_Team_Transformation_A_Case_Study_With_an_ERP_Project/download?_tp=eyJjb250ZXh0Ijp7ImZpcnN0UGFnZSI6InB1YmxpY2F0aW9uIiwicGFnZSI6Il9kaXJlY3QifX0) (Fuente: Sergio García-Campero, actualizado por Alain Villagrasa)
 
 - **Libra y Gobierno del reino Unido**:
 [Courts Libra system 'is one of the worst IT projects ever seen'](https://www.computerweekly.com/news/2240049341/Courts-Libra-system-is-one-of-the-worst-IT-projects-ever-seen) (Fuente: Jaime Conchello)
@@ -374,8 +371,6 @@ Resistencia y falta de indicadores de éxito tras la instalación de un ERP.
 En este paper se hace un pequeño estudio de la implementación de SAP en esta compañía. Se explica que la implementación fue “exitosa” porque su calificación de rendimiento es 5.23 (página 4) lo que revela que no todo el potencial del proyecto fue aprovechado. Se explican los problemas que hubo, como, por ejemplo, las poca confianza y los requisitos poco claros del departamento de ingeniería.
 [A Case Study of a Process Enhancement IT-Project In a Maintenance, Repair and Overhaul Company](http://www.ccsenet.org/journal/index.php/ijbm/article/view/1476) (Fuente: Samuel Ballonga)
 
-- **ERP desconocido y Multi-national Electronics Components Manufacturing Company**:
-[Examining the ERP Implementation Process from a Failure Case](http://www.pacis-net.org/file/2004/P04-005.pdf) (Fuente: Marta Lampaya)
 
 - **ERP Warehouse Automation System y [Sainsbury's](https://www.sainsburys.co.uk/)**:
 Sainsbury's, una de las cadenas de supermercados líderes en el Reino Unido, experimentó un significativo revés tecnológico en 2004 con el fracaso de su proyecto de automatización de almacén. Este proyecto tenía como objetivo mejorar la eficiencia de la cadena de suministro mediante la instalación de sistemas de cumplimiento automatizado en su centro de distribución en Waltham Point, Essex. Se esperaba que un sistema basado en códigos de barras aumentara la eficiencia de las operaciones de almacenamiento. Sin embargo, problemas con la lectura de códigos de barras llevaron a pérdidas de 39 millones de euros en el primer semestre de 2004, conflictos contractuales con Accenture, y una disminución en la competitividad de mercado de Sainsbury's frente a rivales como Asda y Tesco.
@@ -433,7 +428,8 @@ Los problemas para implantar un ERP le costó a la compañía unos 30 millones d
 [Department of Homeland Security – Emerge2 Project – USA](http://calleam.com/WTPF/?p=1865) y [EMERGE2's failure sends DHS back to drawing board](https://fcw.com/workforce/2006/03/emerge2s-failure-sends-dhs-back-to-drawing-board/220017/) (Fuente: Juan Mediano, corrige aportación de Daniel Cabrera)
 
 - **Eclipsys Corporation y [El Camino Hospital](http://www.elcaminohospital.org/)**:
-[Report: ECHO caused problems for hospital](http://www.mv-voice.com/print/story/2006/07/14/hospital-vexed-by-new-computer-system) (Fuente: Edgar Arnal)
+Implementación fallida del ERP de la compañía Eclipsys, que casi provoca la desaparición del hospital y tuvo que retrasarse en 6 meses su despliegue, ver
+[HIStalk Interviews Mark Zielazinski, CIO of Children’s Hospital of Central California](HIStalk Interviews Mark Zielazinski, CIO of Children’s Hospital of Central California) (Alain Villagrasa)
 
 - **Infor y Western Textile Company**:
 [Enterprise Software Companies are Human Too](http://www.erp.com/component/content/article/337-articles-a-news/erp-software/9372-enterprise-software-companies-are-human-too--part-four.html) ( Fuente: Adrián Crespo ).
@@ -683,7 +679,7 @@ Iniciado en 2011, el proyecto eLWIS se cancela en 2017 y Lidl intenta volver a s
 [Evidence from the Oil and Gas Sector](https://www.uni-obuda.hu/journal/Mishra_Mishra_30.pdf) (Fuente: Javier Plano).
 
 - **SAP y Victorian Orden of Nurses (Canada)**:
-[VON struggles to reimburse nurses with pay problems](http://www.cbc.ca/news/canada/von-struggles-to-reimburse-nurses-with-pay-problems-1.1097943) (Fuente: Guillermo Robles) y [SAP-IBM payroll system woes fouled up nurses' pay](http://www.computerworld.com/article/2510412/enterprise-applications/sap-ibm-payroll-system-woes-fouled-up-nurses--pay.html) (Fuente: Nerea Torres)
+[VON struggles to reimburse nurses with pay problems](http://www.cbc.ca/news/canada/von-struggles-to-reimburse-nurses-with-pay-problems-1.1097943) (Fuente: Guillermo Robles, links actualizados por Alain Villagrasa)
 
 - **SAP y Victorian Orden of Nurses (Canada)**:
 [VON struggles to reimburse nurses with pay problems](http://www.cbc.ca/news/canada/von-struggles-to-reimburse-nurses-with-pay-problems-1.1097943) (Fuente: Guillermo Robles) y [SAP-IBM payroll system woes fouled up nurses' pay](https://www.pcworld.com/article/481021/article-649.html) (Fuente: Nerea Torres, link actualizado por Gari Arellano )

--- a/fracasar-con-erp.md
+++ b/fracasar-con-erp.md
@@ -429,7 +429,7 @@ Los problemas para implantar un ERP le costó a la compañía unos 30 millones d
 
 - **Eclipsys Corporation y [El Camino Hospital](http://www.elcaminohospital.org/)**:
 Implementación fallida del ERP de la compañía Eclipsys, que casi provoca la desaparición del hospital y tuvo que retrasarse en 6 meses su despliegue, ver
-[HIStalk Interviews Mark Zielazinski, CIO of Children’s Hospital of Central California](HIStalk Interviews Mark Zielazinski, CIO of Children’s Hospital of Central California) (Alain Villagrasa)
+[HIStalk Interviews Mark Zielazinski, CIO of Children’s Hospital of Central California](https://histalk2.com/2008/01/21/histalk-interviews-mark-zielazinski-cio-of-childrens-hospital-of-central-california/) (Alain Villagrasa)
 
 - **Infor y Western Textile Company**:
 [Enterprise Software Companies are Human Too](http://www.erp.com/component/content/article/337-articles-a-news/erp-software/9372-enterprise-software-companies-are-human-too--part-four.html) ( Fuente: Adrián Crespo ).


### PR DESCRIPTION
- Entrada de _PeopleSoft_: no fue un fracaso real, además el link al artículo ha pasado a ser de pago sin acceso para la Universidad de Zaragoza.
- Entrada de SAP y KuDrink: actualizado el link, el artículo original ha pasado a ser de pago como el anterior, pero se puede descargar a partir del nuevo proporcionado.
- Entrada _ERP desconocido y Multi-national Electronics Components Manufacturing Company_: Eliminada la entrada, el link ha pasado a ser de spam, no se ha encontrado link sustituto por falta de información.
- Entrada _Eclipsys Corporation y [El Camino Hospital](http://www.elcaminohospital.org/)_: Actualizado el link, con una entrevista con el CIO del hospital durante la fallida instalación del ERP que se retrasó 6 meses.
- Entrada SAP y Victorian Orden of Nurses (Canada): Eliminado uno de los 2 links que ha dejado de funcionar.